### PR TITLE
Add AI integration with multi-provider support

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -1,0 +1,297 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// AnthropicProvider implements the Provider interface for Anthropic Claude
+type AnthropicProvider struct {
+	apiKey  string
+	baseURL string
+	model   string
+	client  *http.Client
+}
+
+// NewAnthropicProvider creates a new Anthropic provider
+func NewAnthropicProvider() *AnthropicProvider {
+	return &AnthropicProvider{
+		baseURL: "https://api.anthropic.com/v1",
+		model:   "claude-3-5-sonnet-20241022", // Default model
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Name returns the provider name
+func (a *AnthropicProvider) Name() ProviderType {
+	return ProviderAnthropic
+}
+
+// IsAvailable checks if the provider is configured and available
+func (a *AnthropicProvider) IsAvailable() bool {
+	return a.apiKey != ""
+}
+
+// Configure sets up the provider with configuration
+func (a *AnthropicProvider) Configure(config ProviderConfig) error {
+	a.apiKey = config.APIKey
+	
+	if config.BaseURL != "" {
+		a.baseURL = config.BaseURL
+	}
+	
+	if config.Model != "" {
+		a.model = config.Model
+	}
+	
+	// Configure client timeout from options
+	if config.Options != nil {
+		if timeout, ok := config.Options["timeout"].(int); ok {
+			a.client.Timeout = time.Duration(timeout) * time.Second
+		}
+	}
+	
+	return nil
+}
+
+// Anthropic API structures
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	Messages  []anthropicMessage `json:"messages"`
+	System    string             `json:"system,omitempty"`
+}
+
+type anthropicResponse struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Role    string `json:"role"`
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	Model        string `json:"model"`
+	StopReason   string `json:"stop_reason"`
+	StopSequence string `json:"stop_sequence"`
+	Usage        struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// Complete generates code completion suggestions
+func (a *AnthropicProvider) Complete(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := a.buildCompletionPrompt(req)
+	
+	anthropicReq := anthropicRequest{
+		Model:     a.model,
+		MaxTokens: 150,
+		System:    "You are a helpful code completion assistant. Provide concise, accurate code completions without explanations.",
+		Messages: []anthropicMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+	
+	response, err := a.makeRequest(ctx, anthropicReq)
+	if err != nil {
+		return nil, err
+	}
+	
+	content := ""
+	if len(response.Content) > 0 {
+		content = response.Content[0].Text
+	}
+	
+	return &AIResponse{
+		Content:    content,
+		Confidence: 0.85, // Claude is generally very reliable
+		Provider:   string(ProviderAnthropic),
+		Model:      a.model,
+	}, nil
+}
+
+// Chat handles general conversational requests
+func (a *AnthropicProvider) Chat(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := a.buildChatPrompt(req)
+	
+	anthropicReq := anthropicRequest{
+		Model:     a.model,
+		MaxTokens: 1000,
+		System:    a.getSystemPrompt(req.Type),
+		Messages: []anthropicMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+	
+	response, err := a.makeRequest(ctx, anthropicReq)
+	if err != nil {
+		return nil, err
+	}
+	
+	content := ""
+	if len(response.Content) > 0 {
+		content = response.Content[0].Text
+	}
+	
+	return &AIResponse{
+		Content:    content,
+		Confidence: 0.9, // Claude excels at conversational tasks
+		Provider:   string(ProviderAnthropic),
+		Model:      a.model,
+	}, nil
+}
+
+// Analyze provides code analysis and suggestions
+func (a *AnthropicProvider) Analyze(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := a.buildAnalysisPrompt(req)
+	
+	anthropicReq := anthropicRequest{
+		Model:     a.model,
+		MaxTokens: 800,
+		System:    "You are an expert code reviewer and refactoring assistant. Provide specific, actionable suggestions with clear explanations.",
+		Messages: []anthropicMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+	
+	response, err := a.makeRequest(ctx, anthropicReq)
+	if err != nil {
+		return nil, err
+	}
+	
+	content := ""
+	if len(response.Content) > 0 {
+		content = response.Content[0].Text
+	}
+	
+	return &AIResponse{
+		Content:    content,
+		Confidence: 0.9, // Claude is excellent at code analysis
+		Provider:   string(ProviderAnthropic),
+		Model:      a.model,
+	}, nil
+}
+
+// makeRequest makes an HTTP request to Anthropic API
+func (a *AnthropicProvider) makeRequest(ctx context.Context, req anthropicRequest) (*anthropicResponse, error) {
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", a.baseURL+"/messages", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", a.apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	
+	var response anthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	
+	return &response, nil
+}
+
+// buildCompletionPrompt builds a prompt for code completion
+func (a *AnthropicProvider) buildCompletionPrompt(req AIRequest) string {
+	var prompt strings.Builder
+	
+	if req.Language != "" {
+		prompt.WriteString(fmt.Sprintf("Complete this %s code. Only provide the completion, no explanations:\n\n", req.Language))
+	} else {
+		prompt.WriteString("Complete this code. Only provide the completion, no explanations:\n\n")
+	}
+	
+	if req.Context != "" {
+		prompt.WriteString("Context:\n")
+		prompt.WriteString(req.Context)
+		prompt.WriteString("\n\n")
+	}
+	
+	prompt.WriteString("Code to complete:\n")
+	prompt.WriteString(req.Prompt)
+	
+	return prompt.String()
+}
+
+// buildChatPrompt builds a prompt for chat/explanation requests
+func (a *AnthropicProvider) buildChatPrompt(req AIRequest) string {
+	var prompt strings.Builder
+	
+	if req.Context != "" {
+		prompt.WriteString("Context:\n")
+		prompt.WriteString(req.Context)
+		prompt.WriteString("\n\n")
+	}
+	
+	prompt.WriteString(req.Prompt)
+	
+	return prompt.String()
+}
+
+// buildAnalysisPrompt builds a prompt for code analysis
+func (a *AnthropicProvider) buildAnalysisPrompt(req AIRequest) string {
+	var prompt strings.Builder
+	
+	if req.Language != "" {
+		prompt.WriteString(fmt.Sprintf("Analyze this %s code and suggest specific improvements:\n\n", req.Language))
+	} else {
+		prompt.WriteString("Analyze this code and suggest specific improvements:\n\n")
+	}
+	
+	prompt.WriteString("Code:\n")
+	prompt.WriteString(req.Context)
+	
+	if req.Prompt != "" {
+		prompt.WriteString("\n\nSpecific focus: ")
+		prompt.WriteString(req.Prompt)
+	}
+	
+	prompt.WriteString("\n\nProvide specific, actionable suggestions with explanations.")
+	
+	return prompt.String()
+}
+
+// getSystemPrompt returns appropriate system prompt for request type
+func (a *AnthropicProvider) getSystemPrompt(reqType RequestType) string {
+	switch reqType {
+	case RequestExplanation:
+		return "You are an expert programming educator. Explain code concepts clearly with examples when helpful."
+	case RequestDebug:
+		return "You are an expert debugger. Analyze code carefully to identify issues and provide clear solutions."
+	case RequestDocumentation:
+		return "You are a technical documentation expert. Generate clear, comprehensive documentation that follows best practices."
+	case RequestRefactor:
+		return "You are a senior software engineer specializing in code refactoring. Suggest improvements that enhance readability, maintainability, and performance."
+	default:
+		return "You are a helpful AI programming assistant with expertise across multiple programming languages and best practices."
+	}
+}

--- a/internal/ai/google.go
+++ b/internal/ai/google.go
@@ -1,0 +1,168 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type GoogleProvider struct {
+	apiKey  string
+	baseURL string
+	model   string
+	client  *http.Client
+}
+
+type GoogleRequest struct {
+	Contents []GoogleContent `json:"contents"`
+}
+
+type GoogleContent struct {
+	Parts []GooglePart `json:"parts"`
+	Role  string       `json:"role,omitempty"`
+}
+
+type GooglePart struct {
+	Text string `json:"text"`
+}
+
+type GoogleResponse struct {
+	Candidates []GoogleCandidate `json:"candidates"`
+	Error      *GoogleError      `json:"error,omitempty"`
+}
+
+type GoogleCandidate struct {
+	Content GoogleContent `json:"content"`
+}
+
+type GoogleError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status"`
+}
+
+func NewGoogleProvider() *GoogleProvider {
+	return &GoogleProvider{
+		baseURL: "https://generativelanguage.googleapis.com/v1beta/models",
+		model:   "gemini-1.5-flash",
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (p *GoogleProvider) Name() ProviderType {
+	return ProviderGoogle
+}
+
+func (p *GoogleProvider) IsAvailable() bool {
+	return p.apiKey != ""
+}
+
+func (p *GoogleProvider) Configure(config ProviderConfig) error {
+	if config.APIKey == "" {
+		return fmt.Errorf("google provider requires API key")
+	}
+	
+	p.apiKey = config.APIKey
+	
+	if config.BaseURL != "" {
+		p.baseURL = config.BaseURL
+	}
+	
+	if config.Model != "" {
+		p.model = config.Model
+	}
+	
+	return nil
+}
+
+func (p *GoogleProvider) Complete(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	return p.generateContent(ctx, req, "completion")
+}
+
+func (p *GoogleProvider) Chat(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	return p.generateContent(ctx, req, "chat")
+}
+
+func (p *GoogleProvider) Analyze(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	return p.generateContent(ctx, req, "analysis")
+}
+
+func (p *GoogleProvider) generateContent(ctx context.Context, req AIRequest, requestType string) (*AIResponse, error) {
+	if !p.IsAvailable() {
+		return nil, fmt.Errorf("google provider not configured")
+	}
+
+	prompt := p.buildPrompt(req, requestType)
+	
+	googleReq := GoogleRequest{
+		Contents: []GoogleContent{
+			{
+				Parts: []GooglePart{
+					{Text: prompt},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(googleReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/%s:generateContent?key=%s", p.baseURL, p.model, p.apiKey)
+	
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var googleResp GoogleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&googleResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if googleResp.Error != nil {
+		return nil, fmt.Errorf("google API error: %s", googleResp.Error.Message)
+	}
+
+	if len(googleResp.Candidates) == 0 || len(googleResp.Candidates[0].Content.Parts) == 0 {
+		return nil, fmt.Errorf("no response content from google")
+	}
+
+	response := &AIResponse{
+		Content:  googleResp.Candidates[0].Content.Parts[0].Text,
+		Provider: string(ProviderGoogle),
+		Model:    p.model,
+	}
+
+	return response, nil
+}
+
+func (p *GoogleProvider) buildPrompt(req AIRequest, requestType string) string {
+	switch requestType {
+	case "completion":
+		return fmt.Sprintf("Complete the following code:\n\n%s", req.Prompt)
+	case "chat":
+		if req.Context != "" {
+			return fmt.Sprintf("Context: %s\n\nQuestion: %s", req.Context, req.Prompt)
+		}
+		return req.Prompt
+	case "analysis":
+		return fmt.Sprintf("Analyze the following code and provide suggestions:\n\n%s", req.Prompt)
+	default:
+		return req.Prompt
+	}
+}

--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -1,0 +1,252 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type OllamaProvider struct {
+	baseURL string
+	model   string
+	client  *http.Client
+}
+
+type OllamaRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"`
+}
+
+type OllamaChatRequest struct {
+	Model    string           `json:"model"`
+	Messages []OllamaMessage  `json:"messages"`
+	Stream   bool             `json:"stream"`
+}
+
+type OllamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type OllamaResponse struct {
+	Response string `json:"response"`
+	Done     bool   `json:"done"`
+	Error    string `json:"error,omitempty"`
+}
+
+type OllamaChatResponse struct {
+	Message OllamaMessage `json:"message"`
+	Done    bool          `json:"done"`
+	Error   string        `json:"error,omitempty"`
+}
+
+type OllamaTagsResponse struct {
+	Models []OllamaModel `json:"models"`
+}
+
+type OllamaModel struct {
+	Name string `json:"name"`
+}
+
+func NewOllamaProvider() *OllamaProvider {
+	return &OllamaProvider{
+		baseURL: "http://localhost:11434",
+		model:   "llama2",
+		client: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+func (p *OllamaProvider) Name() ProviderType {
+	return ProviderOllama
+}
+
+func (p *OllamaProvider) IsAvailable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	
+	req, err := http.NewRequestWithContext(ctx, "GET", p.baseURL+"/api/tags", nil)
+	if err != nil {
+		return false
+	}
+	
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	
+	return resp.StatusCode == http.StatusOK
+}
+
+func (p *OllamaProvider) Configure(config ProviderConfig) error {
+	if config.BaseURL != "" {
+		p.baseURL = config.BaseURL
+	}
+	
+	if config.Model != "" {
+		p.model = config.Model
+	}
+	
+	return nil
+}
+
+func (p *OllamaProvider) Complete(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := p.buildPrompt(req, "completion")
+	
+	ollamaReq := OllamaRequest{
+		Model:  p.model,
+		Prompt: prompt,
+		Stream: false,
+	}
+
+	jsonData, err := json.Marshal(ollamaReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/api/generate", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var ollamaResp OllamaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if ollamaResp.Error != "" {
+		return nil, fmt.Errorf("ollama API error: %s", ollamaResp.Error)
+	}
+
+	response := &AIResponse{
+		Content:  ollamaResp.Response,
+		Provider: string(ProviderOllama),
+		Model:    p.model,
+	}
+
+	return response, nil
+}
+
+func (p *OllamaProvider) Chat(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	messages := []OllamaMessage{
+		{Role: "user", Content: req.Prompt},
+	}
+	
+	if req.Context != "" {
+		messages = []OllamaMessage{
+			{Role: "system", Content: req.Context},
+			{Role: "user", Content: req.Prompt},
+		}
+	}
+	
+	ollamaReq := OllamaChatRequest{
+		Model:    p.model,
+		Messages: messages,
+		Stream:   false,
+	}
+
+	jsonData, err := json.Marshal(ollamaReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/api/chat", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var ollamaResp OllamaChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if ollamaResp.Error != "" {
+		return nil, fmt.Errorf("ollama API error: %s", ollamaResp.Error)
+	}
+
+	response := &AIResponse{
+		Content:  ollamaResp.Message.Content,
+		Provider: string(ProviderOllama),
+		Model:    p.model,
+	}
+
+	return response, nil
+}
+
+func (p *OllamaProvider) Analyze(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := p.buildPrompt(req, "analysis")
+	
+	ollamaReq := OllamaRequest{
+		Model:  p.model,
+		Prompt: prompt,
+		Stream: false,
+	}
+
+	jsonData, err := json.Marshal(ollamaReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/api/generate", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var ollamaResp OllamaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if ollamaResp.Error != "" {
+		return nil, fmt.Errorf("ollama API error: %s", ollamaResp.Error)
+	}
+
+	response := &AIResponse{
+		Content:  ollamaResp.Response,
+		Provider: string(ProviderOllama),
+		Model:    p.model,
+	}
+
+	return response, nil
+}
+
+func (p *OllamaProvider) buildPrompt(req AIRequest, requestType string) string {
+	switch requestType {
+	case "completion":
+		return fmt.Sprintf("Complete the following code:\n\n%s", req.Prompt)
+	case "analysis":
+		return fmt.Sprintf("Analyze the following code and provide suggestions for improvement:\n\n%s", req.Prompt)
+	default:
+		return req.Prompt
+	}
+}

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -1,0 +1,292 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// OpenAIProvider implements the Provider interface for OpenAI
+type OpenAIProvider struct {
+	apiKey  string
+	baseURL string
+	model   string
+	client  *http.Client
+}
+
+// NewOpenAIProvider creates a new OpenAI provider
+func NewOpenAIProvider() *OpenAIProvider {
+	return &OpenAIProvider{
+		baseURL: "https://api.openai.com/v1",
+		model:   "gpt-4", // Default model
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Name returns the provider name
+func (o *OpenAIProvider) Name() ProviderType {
+	return ProviderOpenAI
+}
+
+// IsAvailable checks if the provider is configured and available
+func (o *OpenAIProvider) IsAvailable() bool {
+	return o.apiKey != ""
+}
+
+// Configure sets up the provider with configuration
+func (o *OpenAIProvider) Configure(config ProviderConfig) error {
+	o.apiKey = config.APIKey
+	
+	if config.BaseURL != "" {
+		o.baseURL = config.BaseURL
+	}
+	
+	if config.Model != "" {
+		o.model = config.Model
+	}
+	
+	// Configure client timeout from options
+	if config.Options != nil {
+		if timeout, ok := config.Options["timeout"].(int); ok {
+			o.client.Timeout = time.Duration(timeout) * time.Second
+		}
+	}
+	
+	return nil
+}
+
+// OpenAI API structures
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIChatRequest struct {
+	Model       string          `json:"model"`
+	Messages    []openAIMessage `json:"messages"`
+	MaxTokens   int             `json:"max_tokens,omitempty"`
+	Temperature float64         `json:"temperature,omitempty"`
+	Stream      bool            `json:"stream"`
+}
+
+type openAIChatResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// Complete generates code completion suggestions
+func (o *OpenAIProvider) Complete(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := o.buildCompletionPrompt(req)
+	
+	chatReq := openAIChatRequest{
+		Model: o.model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: "You are a helpful code completion assistant. Provide concise, accurate code completions."},
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens:   150,
+		Temperature: 0.1, // Low temperature for more deterministic completions
+		Stream:      false,
+	}
+	
+	response, err := o.makeRequest(ctx, chatReq)
+	if err != nil {
+		return nil, err
+	}
+	
+	return &AIResponse{
+		Content:    response.Choices[0].Message.Content,
+		Confidence: 0.8, // Default confidence
+		Provider:   string(ProviderOpenAI),
+		Model:      o.model,
+	}, nil
+}
+
+// Chat handles general conversational requests
+func (o *OpenAIProvider) Chat(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := o.buildChatPrompt(req)
+	
+	chatReq := openAIChatRequest{
+		Model: o.model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: o.getSystemPrompt(req.Type)},
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens:   1000,
+		Temperature: 0.3,
+		Stream:      false,
+	}
+	
+	response, err := o.makeRequest(ctx, chatReq)
+	if err != nil {
+		return nil, err
+	}
+	
+	return &AIResponse{
+		Content:    response.Choices[0].Message.Content,
+		Confidence: 0.9,
+		Provider:   string(ProviderOpenAI),
+		Model:      o.model,
+	}, nil
+}
+
+// Analyze provides code analysis and suggestions
+func (o *OpenAIProvider) Analyze(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	prompt := o.buildAnalysisPrompt(req)
+	
+	chatReq := openAIChatRequest{
+		Model: o.model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: "You are an expert code reviewer and refactoring assistant. Provide specific, actionable suggestions."},
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens:   800,
+		Temperature: 0.2,
+		Stream:      false,
+	}
+	
+	response, err := o.makeRequest(ctx, chatReq)
+	if err != nil {
+		return nil, err
+	}
+	
+	return &AIResponse{
+		Content:    response.Choices[0].Message.Content,
+		Confidence: 0.85,
+		Provider:   string(ProviderOpenAI),
+		Model:      o.model,
+	}, nil
+}
+
+// makeRequest makes an HTTP request to OpenAI API
+func (o *OpenAIProvider) makeRequest(ctx context.Context, req openAIChatRequest) (*openAIChatResponse, error) {
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	
+	resp, err := o.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	
+	var response openAIChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	
+	if len(response.Choices) == 0 {
+		return nil, fmt.Errorf("no response choices returned")
+	}
+	
+	return &response, nil
+}
+
+// buildCompletionPrompt builds a prompt for code completion
+func (o *OpenAIProvider) buildCompletionPrompt(req AIRequest) string {
+	var prompt strings.Builder
+	
+	if req.Language != "" {
+		prompt.WriteString(fmt.Sprintf("Complete this %s code:\n\n", req.Language))
+	} else {
+		prompt.WriteString("Complete this code:\n\n")
+	}
+	
+	if req.Context != "" {
+		prompt.WriteString("Context:\n")
+		prompt.WriteString(req.Context)
+		prompt.WriteString("\n\n")
+	}
+	
+	prompt.WriteString("Code to complete:\n")
+	prompt.WriteString(req.Prompt)
+	
+	return prompt.String()
+}
+
+// buildChatPrompt builds a prompt for chat/explanation requests
+func (o *OpenAIProvider) buildChatPrompt(req AIRequest) string {
+	var prompt strings.Builder
+	
+	if req.Context != "" {
+		prompt.WriteString("Context:\n")
+		prompt.WriteString(req.Context)
+		prompt.WriteString("\n\n")
+	}
+	
+	prompt.WriteString("Question: ")
+	prompt.WriteString(req.Prompt)
+	
+	return prompt.String()
+}
+
+// buildAnalysisPrompt builds a prompt for code analysis
+func (o *OpenAIProvider) buildAnalysisPrompt(req AIRequest) string {
+	var prompt strings.Builder
+	
+	if req.Language != "" {
+		prompt.WriteString(fmt.Sprintf("Analyze this %s code and suggest improvements:\n\n", req.Language))
+	} else {
+		prompt.WriteString("Analyze this code and suggest improvements:\n\n")
+	}
+	
+	prompt.WriteString("Code:\n")
+	prompt.WriteString(req.Context)
+	
+	if req.Prompt != "" {
+		prompt.WriteString("\n\nSpecific focus: ")
+		prompt.WriteString(req.Prompt)
+	}
+	
+	return prompt.String()
+}
+
+// getSystemPrompt returns appropriate system prompt for request type
+func (o *OpenAIProvider) getSystemPrompt(reqType RequestType) string {
+	switch reqType {
+	case RequestExplanation:
+		return "You are a helpful programming tutor. Explain code concepts clearly and concisely."
+	case RequestDebug:
+		return "You are an expert debugger. Help identify and fix issues in code."
+	case RequestDocumentation:
+		return "You are a technical writer. Generate clear, comprehensive documentation."
+	default:
+		return "You are a helpful AI programming assistant."
+	}
+}

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -1,0 +1,241 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+)
+
+// ProviderType represents different AI providers
+type ProviderType string
+
+const (
+	ProviderOpenAI    ProviderType = "openai"
+	ProviderAnthropic ProviderType = "anthropic"
+	ProviderGoogle    ProviderType = "google"
+	ProviderOllama    ProviderType = "ollama"
+)
+
+// AIRequest represents a request to an AI provider
+type AIRequest struct {
+	Prompt      string            // The main prompt/question
+	Context     string            // Additional context (code, file content, etc.)
+	Language    string            // Programming language for context
+	Type        RequestType       // Type of AI assistance requested
+	Options     map[string]interface{} // Provider-specific options
+}
+
+// RequestType represents different types of AI assistance
+type RequestType string
+
+const (
+	RequestCompletion   RequestType = "completion"   // Code completion
+	RequestExplanation  RequestType = "explanation"  // Explain code/concept
+	RequestRefactor     RequestType = "refactor"     // Suggest refactoring
+	RequestDebug        RequestType = "debug"        // Debug help
+	RequestDocumentation RequestType = "documentation" // Generate docs
+	RequestChat         RequestType = "chat"         // General chat/help
+)
+
+// AIResponse represents the response from an AI provider
+type AIResponse struct {
+	Content     string   // The AI's response content
+	Suggestions []string // List of suggestions (for completion)
+	Confidence  float64  // Confidence score (0.0 to 1.0)
+	Error       error    // Any error that occurred
+	Provider    string   // Which provider generated this response
+	Model       string   // Which model was used
+}
+
+// Provider defines the interface that all AI providers must implement
+type Provider interface {
+	// Name returns the provider name
+	Name() ProviderType
+	
+	// IsAvailable checks if the provider is configured and available
+	IsAvailable() bool
+	
+	// Complete generates code completion suggestions
+	Complete(ctx context.Context, req AIRequest) (*AIResponse, error)
+	
+	// Chat handles general conversational requests
+	Chat(ctx context.Context, req AIRequest) (*AIResponse, error)
+	
+	// Analyze provides code analysis and suggestions
+	Analyze(ctx context.Context, req AIRequest) (*AIResponse, error)
+	
+	// Configure sets up the provider with configuration
+	Configure(config ProviderConfig) error
+}
+
+// ProviderConfig holds configuration for AI providers
+type ProviderConfig struct {
+	Type       ProviderType          `yaml:"type"`
+	APIKey     string                `yaml:"api_key"`
+	BaseURL    string                `yaml:"base_url"`
+	Model      string                `yaml:"model"`
+	Options    map[string]interface{} `yaml:"options"`
+	Enabled    bool                  `yaml:"enabled"`
+}
+
+// AIManager manages multiple AI providers and routing
+type AIManager struct {
+	providers     map[ProviderType]Provider
+	activeProvider ProviderType
+	fallbackOrder []ProviderType
+}
+
+// NewAIManager creates a new AI manager
+func NewAIManager() *AIManager {
+	return &AIManager{
+		providers: make(map[ProviderType]Provider),
+		fallbackOrder: []ProviderType{
+			ProviderOllama,    // Local first (no API costs)
+			ProviderOpenAI,    // Popular and reliable
+			ProviderAnthropic, // High quality
+			ProviderGoogle,    // Good alternative
+		},
+	}
+}
+
+// RegisterProvider registers an AI provider
+func (am *AIManager) RegisterProvider(provider Provider) error {
+	if provider == nil {
+		return fmt.Errorf("provider cannot be nil")
+	}
+	
+	am.providers[provider.Name()] = provider
+	
+	// Set as active if it's the first available provider
+	if am.activeProvider == "" && provider.IsAvailable() {
+		am.activeProvider = provider.Name()
+	}
+	
+	return nil
+}
+
+// SetActiveProvider sets the active AI provider
+func (am *AIManager) SetActiveProvider(providerType ProviderType) error {
+	provider, exists := am.providers[providerType]
+	if !exists {
+		return fmt.Errorf("provider %s not registered", providerType)
+	}
+	
+	if !provider.IsAvailable() {
+		return fmt.Errorf("provider %s not available", providerType)
+	}
+	
+	am.activeProvider = providerType
+	return nil
+}
+
+// GetActiveProvider returns the currently active provider
+func (am *AIManager) GetActiveProvider() Provider {
+	if am.activeProvider == "" {
+		return nil
+	}
+	
+	return am.providers[am.activeProvider]
+}
+
+// GetProvider returns a specific provider by type
+func (am *AIManager) GetProvider(providerType ProviderType) (Provider, bool) {
+	provider, exists := am.providers[providerType]
+	return provider, exists
+}
+
+// ListProviders returns all registered providers
+func (am *AIManager) ListProviders() map[ProviderType]Provider {
+	return am.providers
+}
+
+// ListAvailableProviders returns only available providers
+func (am *AIManager) ListAvailableProviders() map[ProviderType]Provider {
+	available := make(map[ProviderType]Provider)
+	for pType, provider := range am.providers {
+		if provider.IsAvailable() {
+			available[pType] = provider
+		}
+	}
+	return available
+}
+
+// Request makes an AI request using the active provider with fallback
+func (am *AIManager) Request(ctx context.Context, req AIRequest) (*AIResponse, error) {
+	// Try active provider first
+	if am.activeProvider != "" {
+		if provider := am.providers[am.activeProvider]; provider != nil && provider.IsAvailable() {
+			response, err := am.makeRequest(ctx, provider, req)
+			if err == nil {
+				return response, nil
+			}
+			// Log error but continue to fallback
+		}
+	}
+	
+	// Try fallback providers
+	for _, providerType := range am.fallbackOrder {
+		provider, exists := am.providers[providerType]
+		if !exists || !provider.IsAvailable() || providerType == am.activeProvider {
+			continue
+		}
+		
+		response, err := am.makeRequest(ctx, provider, req)
+		if err == nil {
+			return response, nil
+		}
+	}
+	
+	return nil, fmt.Errorf("no available AI providers")
+}
+
+// makeRequest makes a request to a specific provider based on request type
+func (am *AIManager) makeRequest(ctx context.Context, provider Provider, req AIRequest) (*AIResponse, error) {
+	switch req.Type {
+	case RequestCompletion:
+		return provider.Complete(ctx, req)
+	case RequestChat, RequestExplanation, RequestDebug, RequestDocumentation:
+		return provider.Chat(ctx, req)
+	case RequestRefactor:
+		return provider.Analyze(ctx, req)
+	default:
+		return provider.Chat(ctx, req)
+	}
+}
+
+// ConfigureProviders configures multiple providers from config
+func (am *AIManager) ConfigureProviders(configs []ProviderConfig) error {
+	for _, config := range configs {
+		if !config.Enabled {
+			continue
+		}
+		
+		provider, err := CreateProvider(config.Type)
+		if err != nil {
+			continue // Skip unavailable providers
+		}
+		
+		if err := provider.Configure(config); err != nil {
+			continue // Skip failed configurations
+		}
+		
+		am.RegisterProvider(provider)
+	}
+	
+	return nil
+}
+
+// CreateProvider creates a provider instance by type
+func CreateProvider(providerType ProviderType) (Provider, error) {
+	switch providerType {
+	case ProviderOpenAI:
+		return NewOpenAIProvider(), nil
+	case ProviderAnthropic:
+		return NewAnthropicProvider(), nil
+	case ProviderGoogle:
+		return NewGoogleProvider(), nil
+	case ProviderOllama:
+		return NewOllamaProvider(), nil
+	default:
+		return nil, fmt.Errorf("unknown provider type: %s", providerType)
+	}
+}

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -171,6 +171,29 @@ func (b *Buffer) InsertChar(ch rune) error {
 	return nil
 }
 
+// InsertTextAt inserts text at a specific position
+func (b *Buffer) InsertTextAt(line, col int, text string) error {
+	if line < 0 || line >= len(b.lines) {
+		return fmt.Errorf("line %d out of range", line)
+	}
+
+	lineContent := b.lines[line]
+	if col < 0 || col > len(lineContent) {
+		return fmt.Errorf("column %d out of range for line length %d", col, len(lineContent))
+	}
+
+	// Insert text at the specified position
+	newLine := lineContent[:col] + text + lineContent[col:]
+	b.lines[line] = newLine
+	
+	// Move cursor to end of inserted text
+	b.cursor.Line = line
+	b.cursor.Col = col + len(text)
+	b.setModified(true)
+
+	return nil
+}
+
 // DeleteChar deletes the character at the current cursor position
 func (b *Buffer) DeleteChar() error {
 	if b.cursor.Line < 0 || b.cursor.Line >= len(b.lines) {

--- a/internal/commands/ai_commands.go
+++ b/internal/commands/ai_commands.go
@@ -1,0 +1,414 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dshills/aied/internal/ai"
+	"github.com/dshills/aied/internal/buffer"
+)
+
+// Global AI manager - will be initialized from main
+var aiManager *ai.AIManager
+
+// SetAIManager sets the global AI manager for commands
+func SetAIManager(manager *ai.AIManager) {
+	aiManager = manager
+}
+
+// AICompleteCommand implements AI-powered code completion
+type AICompleteCommand struct{}
+
+func NewAICompleteCommand() *AICompleteCommand {
+	return &AICompleteCommand{}
+}
+
+func (c *AICompleteCommand) Name() string {
+	return "aicomplete"
+}
+
+func (c *AICompleteCommand) Aliases() []string {
+	return []string{"aic"}
+}
+
+func (c *AICompleteCommand) Execute(args []string, buf *buffer.Buffer) CommandResult {
+	if aiManager == nil {
+		return CommandResult{
+			Success:    false,
+			Message:    "AI manager not initialized",
+			SwitchMode: true,
+		}
+	}
+
+	// Get current line or selection
+	cursor := buf.Cursor()
+	currentLine := buf.CurrentLine()
+	
+	// Get context (surrounding lines)
+	contextLines := 10
+	startLine := cursor.Line - contextLines
+	if startLine < 0 {
+		startLine = 0
+	}
+	endLine := cursor.Line + contextLines
+	if endLine >= buf.LineCount() {
+		endLine = buf.LineCount() - 1
+	}
+	
+	var contextBuilder strings.Builder
+	for i := startLine; i <= endLine; i++ {
+		if i == cursor.Line {
+			contextBuilder.WriteString(">>> ")
+		}
+		lineContent, _ := buf.Line(i)
+		contextBuilder.WriteString(lineContent)
+		contextBuilder.WriteString("\n")
+	}
+
+	// Create AI request
+	req := ai.AIRequest{
+		Prompt:   currentLine[:cursor.Col], // Everything before cursor
+		Context:  contextBuilder.String(),
+		Language: detectLanguage(buf.Filename()),
+		Type:     ai.RequestCompletion,
+	}
+
+	// Make AI request with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := aiManager.Request(ctx, req)
+	if err != nil {
+		return CommandResult{
+			Success:    false,
+			Message:    fmt.Sprintf("AI error: %s", err.Error()),
+			SwitchMode: true,
+		}
+	}
+
+	// Insert completion at cursor
+	buf.InsertTextAt(cursor.Line, cursor.Col, resp.Content)
+
+	return CommandResult{
+		Success:    true,
+		Message:    fmt.Sprintf("Completed with %s", resp.Provider),
+		SwitchMode: true,
+	}
+}
+
+func (c *AICompleteCommand) Help() string {
+	return "Complete code at cursor position using AI"
+}
+
+// AIExplainCommand explains selected code or current line
+type AIExplainCommand struct{}
+
+func NewAIExplainCommand() *AIExplainCommand {
+	return &AIExplainCommand{}
+}
+
+func (c *AIExplainCommand) Name() string {
+	return "aiexplain"
+}
+
+func (c *AIExplainCommand) Aliases() []string {
+	return []string{"aie"}
+}
+
+func (c *AIExplainCommand) Execute(args []string, buf *buffer.Buffer) CommandResult {
+	if aiManager == nil {
+		return CommandResult{
+			Success:    false,
+			Message:    "AI manager not initialized",
+			SwitchMode: true,
+		}
+	}
+
+	// Get current line or selection (for now just current line)
+	codeToExplain := buf.CurrentLine()
+
+	if len(args) > 0 {
+		// If args provided, use them as the code to explain
+		codeToExplain = strings.Join(args, " ")
+	}
+
+	// Create AI request
+	req := ai.AIRequest{
+		Prompt:   fmt.Sprintf("Explain this code: %s", codeToExplain),
+		Language: detectLanguage(buf.Filename()),
+		Type:     ai.RequestExplanation,
+	}
+
+	// Make AI request
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := aiManager.Request(ctx, req)
+	if err != nil {
+		return CommandResult{
+			Success:    false,
+			Message:    fmt.Sprintf("AI error: %s", err.Error()),
+			SwitchMode: true,
+		}
+	}
+
+	// For now, just show the message - later we'll add a popup or split view
+	return CommandResult{
+		Success:    true,
+		Message:    resp.Content,
+		SwitchMode: true,
+	}
+}
+
+func (c *AIExplainCommand) Help() string {
+	return "Explain code at cursor or provided as argument"
+}
+
+// AIRefactorCommand suggests refactoring for selected code
+type AIRefactorCommand struct{}
+
+func NewAIRefactorCommand() *AIRefactorCommand {
+	return &AIRefactorCommand{}
+}
+
+func (c *AIRefactorCommand) Name() string {
+	return "airefactor"
+}
+
+func (c *AIRefactorCommand) Aliases() []string {
+	return []string{"air"}
+}
+
+func (c *AIRefactorCommand) Execute(args []string, buf *buffer.Buffer) CommandResult {
+	if aiManager == nil {
+		return CommandResult{
+			Success:    false,
+			Message:    "AI manager not initialized",
+			SwitchMode: true,
+		}
+	}
+
+	// Get current function or block (for now just current line)
+	codeToRefactor := buf.CurrentLine()
+
+	// Create AI request
+	req := ai.AIRequest{
+		Prompt:   codeToRefactor,
+		Language: detectLanguage(buf.Filename()),
+		Type:     ai.RequestRefactor,
+	}
+
+	// Make AI request
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := aiManager.Request(ctx, req)
+	if err != nil {
+		return CommandResult{
+			Success:    false,
+			Message:    fmt.Sprintf("AI error: %s", err.Error()),
+			SwitchMode: true,
+		}
+	}
+
+	// For now, show suggestion - later we'll add preview and apply
+	return CommandResult{
+		Success:    true,
+		Message:    fmt.Sprintf("Refactor suggestion: %s", resp.Content),
+		SwitchMode: true,
+	}
+}
+
+func (c *AIRefactorCommand) Help() string {
+	return "Get AI suggestions for refactoring code"
+}
+
+// AIChatCommand opens AI chat for general help
+type AIChatCommand struct{}
+
+func NewAIChatCommand() *AIChatCommand {
+	return &AIChatCommand{}
+}
+
+func (c *AIChatCommand) Name() string {
+	return "ai"
+}
+
+func (c *AIChatCommand) Aliases() []string {
+	return []string{}
+}
+
+func (c *AIChatCommand) Execute(args []string, buf *buffer.Buffer) CommandResult {
+	if aiManager == nil {
+		return CommandResult{
+			Success:    false,
+			Message:    "AI manager not initialized",
+			SwitchMode: true,
+		}
+	}
+
+	if len(args) == 0 {
+		return CommandResult{
+			Success:    false,
+			Message:    "Usage: :ai <question>",
+			SwitchMode: true,
+		}
+	}
+
+	question := strings.Join(args, " ")
+
+	// Get current file context
+	var contextBuilder strings.Builder
+	contextBuilder.WriteString(fmt.Sprintf("File: %s\n", buf.Filename()))
+	contextBuilder.WriteString(fmt.Sprintf("Language: %s\n", detectLanguage(buf.Filename())))
+	
+	// Add current line info
+	cursor := buf.Cursor()
+	contextBuilder.WriteString(fmt.Sprintf("Current line %d: %s\n", cursor.Line+1, buf.CurrentLine()))
+	contextBuilder.WriteString(fmt.Sprintf("Cursor at column %d\n", cursor.Col))
+
+	// Create AI request
+	req := ai.AIRequest{
+		Prompt:   question,
+		Context:  contextBuilder.String(),
+		Type:     ai.RequestChat,
+	}
+
+	// Make AI request
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := aiManager.Request(ctx, req)
+	if err != nil {
+		return CommandResult{
+			Success:    false,
+			Message:    fmt.Sprintf("AI error: %s", err.Error()),
+			SwitchMode: true,
+		}
+	}
+
+	return CommandResult{
+		Success:    true,
+		Message:    resp.Content,
+		SwitchMode: true,
+	}
+}
+
+func (c *AIChatCommand) Help() string {
+	return "Ask AI a general question about your code"
+}
+
+// AIProviderCommand manages AI providers
+type AIProviderCommand struct{}
+
+func NewAIProviderCommand() *AIProviderCommand {
+	return &AIProviderCommand{}
+}
+
+func (c *AIProviderCommand) Name() string {
+	return "aiprovider"
+}
+
+func (c *AIProviderCommand) Aliases() []string {
+	return []string{"aip"}
+}
+
+func (c *AIProviderCommand) Execute(args []string, buf *buffer.Buffer) CommandResult {
+	if aiManager == nil {
+		return CommandResult{
+			Success:    false,
+			Message:    "AI manager not initialized",
+			SwitchMode: true,
+		}
+	}
+
+	if len(args) == 0 {
+		// List available providers
+		providers := aiManager.ListAvailableProviders()
+		active := aiManager.GetActiveProvider()
+		
+		var providerList []string
+		for pType, provider := range providers {
+			marker := ""
+			if active != nil && provider.Name() == active.Name() {
+				marker = " (active)"
+			}
+			providerList = append(providerList, fmt.Sprintf("%s%s", pType, marker))
+		}
+		
+		if len(providerList) == 0 {
+			return CommandResult{
+				Success:    true,
+				Message:    "No AI providers available",
+				SwitchMode: true,
+			}
+		}
+		
+		return CommandResult{
+			Success:    true,
+			Message:    fmt.Sprintf("Available providers: %s", strings.Join(providerList, ", ")),
+			SwitchMode: true,
+		}
+	}
+
+	// Set active provider
+	providerType := ai.ProviderType(args[0])
+	err := aiManager.SetActiveProvider(providerType)
+	if err != nil {
+		return CommandResult{
+			Success:    false,
+			Message:    fmt.Sprintf("Failed to set provider: %s", err.Error()),
+			SwitchMode: true,
+		}
+	}
+
+	return CommandResult{
+		Success:    true,
+		Message:    fmt.Sprintf("Active provider set to: %s", providerType),
+		SwitchMode: true,
+	}
+}
+
+func (c *AIProviderCommand) Help() string {
+	return "List or set active AI provider"
+}
+
+// Helper function to detect programming language from filename
+func detectLanguage(filename string) string {
+	parts := strings.Split(filename, ".")
+	if len(parts) < 2 {
+		return "text"
+	}
+	
+	ext := parts[len(parts)-1]
+	switch ext {
+	case "go":
+		return "go"
+	case "py":
+		return "python"
+	case "js", "jsx":
+		return "javascript"
+	case "ts", "tsx":
+		return "typescript"
+	case "java":
+		return "java"
+	case "c":
+		return "c"
+	case "cpp", "cc", "cxx":
+		return "cpp"
+	case "rs":
+		return "rust"
+	case "rb":
+		return "ruby"
+	case "php":
+		return "php"
+	case "sh", "bash":
+		return "bash"
+	case "md":
+		return "markdown"
+	default:
+		return "text"
+	}
+}

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -49,6 +49,13 @@ func NewCommandRegistry() *CommandRegistry {
 	registry.RegisterCommand(NewEditCommand())
 	registry.RegisterCommand(NewNewCommand())
 	
+	// Register AI commands
+	registry.RegisterCommand(NewAICompleteCommand())
+	registry.RegisterCommand(NewAIExplainCommand())
+	registry.RegisterCommand(NewAIRefactorCommand())
+	registry.RegisterCommand(NewAIChatCommand())
+	registry.RegisterCommand(NewAIProviderCommand())
+	
 	return registry
 }
 

--- a/main.go
+++ b/main.go
@@ -4,12 +4,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dshills/aied/internal/ai"
 	"github.com/dshills/aied/internal/buffer"
+	"github.com/dshills/aied/internal/commands"
 	"github.com/dshills/aied/internal/modes"
 	"github.com/dshills/aied/internal/ui"
 )
 
 func main() {
+	// Initialize AI system
+	aiManager := initializeAI()
+	commands.SetAIManager(aiManager)
+
 	// Create a new buffer
 	var buf *buffer.Buffer
 	var err error
@@ -93,4 +99,49 @@ func handleFallbackKeyEvent(event ui.KeyEvent, buf *buffer.Buffer, terminalUI *u
 	}
 
 	return false
+}
+
+// initializeAI sets up the AI system with available providers
+func initializeAI() *ai.AIManager {
+	aiManager := ai.NewAIManager()
+
+	// Initialize providers based on environment variables
+	// OpenAI
+	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
+		provider := ai.NewOpenAIProvider()
+		provider.Configure(ai.ProviderConfig{
+			APIKey: apiKey,
+			Model:  "gpt-4",
+		})
+		aiManager.RegisterProvider(provider)
+	}
+
+	// Anthropic
+	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
+		provider := ai.NewAnthropicProvider()
+		provider.Configure(ai.ProviderConfig{
+			APIKey: apiKey,
+			Model:  "claude-3-5-sonnet-20241022",
+		})
+		aiManager.RegisterProvider(provider)
+	}
+
+	// Google
+	if apiKey := os.Getenv("GOOGLE_API_KEY"); apiKey != "" {
+		provider := ai.NewGoogleProvider()
+		provider.Configure(ai.ProviderConfig{
+			APIKey: apiKey,
+			Model:  "gemini-1.5-flash",
+		})
+		aiManager.RegisterProvider(provider)
+	}
+
+	// Ollama (always try to register - it will check if available)
+	ollamaProvider := ai.NewOllamaProvider()
+	ollamaProvider.Configure(ai.ProviderConfig{
+		Model: "llama2",
+	})
+	aiManager.RegisterProvider(ollamaProvider)
+
+	return aiManager
 }


### PR DESCRIPTION
## Summary
- Implemented comprehensive AI system with provider abstraction supporting Google, OpenAI, Anthropic, and Ollama
- Added AI commands (:ai, :aic, :aie, :air, :aip) for code completion, explanation, refactoring, and chat
- Integrated AI initialization in main.go with automatic provider detection from environment variables

## Test plan
- [ ] Set environment variables for desired AI providers (OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY)
- [ ] Test :aip command to list available providers
- [ ] Test :ai <question> for general AI assistance
- [ ] Test :aic for code completion at cursor
- [ ] Test :aie for code explanation
- [ ] Test :air for refactoring suggestions
- [ ] Test provider switching with :aip <provider>
- [ ] Verify Ollama provider works if Ollama is running locally

🤖 Generated with [Claude Code](https://claude.ai/code)